### PR TITLE
AR_OpenProjectFolder.py

### DIFF
--- a/AR_Scripts_1.58_R25/Utility/AR_OpenProjectFolder.py
+++ b/AR_Scripts_1.58_R25/Utility/AR_OpenProjectFolder.py
@@ -1,0 +1,27 @@
+"""
+AR_OpenProjectFolder
+
+Author: Arttu Rautio (aturtur)
+Website: http://aturtur.com/
+Name-US: AR_OpenProjectFolder
+Version: 1.0
+Description-US: Opens folder where project is saved
+
+Written for Maxon Cinema 4D R25+
+Python version 3.9.1
+
+R26 Update: Toms Seglins (tomsvfx)
+"""
+# Libraries
+import c4d
+
+# Functions
+def main():
+    doc = c4d.documents.GetActiveDocument() # Get active document
+    path = doc.GetDocumentPath() # Get file path of project
+    if path != "": # If path is not empty
+        c4d.storage.ShowInFinder(path, True) # Open project folder
+
+# Execute main()
+if __name__=='__main__':
+    main()


### PR DESCRIPTION
In S26 there was an issue that this script opened the parent folder of scene files folder.
For example, the Python 2 version script was working in R25 without issues. 

This updated version also works in R25.

The main thing I changed to make it work as expected was:
c4d.storage.ShowInFinder(path, False) 
changed to 
c4d.storage.ShowInFinder(path, True)